### PR TITLE
Handling remove company account, billing, paycheck and ox_inventory bank card

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -7,6 +7,8 @@ Config.Paycheck = {
 
 Config.OxInventory = ESX.GetConfig().OxInventory
 
+Config.EnableCompanyPayouts = true
+
 -- You should not need BusinessAccounts when using ESX & esx_society
 Config.BusinessAccounts = {
     -- ['police'] = { -- Job Name
@@ -25,5 +27,12 @@ Config.Locale = {
     deposited = "Deposited money into society account",
     withdrew = "Withdrew money from society account",
     addItemSuccess = 'You got new Visa.',
-    addItemFailed = 'Failed to give new visa, reason:'
+    addItemFailed = 'Failed to give new visa, reason:',
+    welfareCheck = 'Welfare Check',
+    bankName = 'Maze Bank',
+    receivedPayCheck = 'Received paycheck',
+    receivedHelp = 'You have been paid your welfare check: $',
+    transferPayCheck = 'Transfer paycheck',
+    receivedSalary = 'You have been paid: $',
+    companyCantAfford = 'the company you\'re employeed at is too poor to pay out your salary'
 }

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,7 @@ Config = {}
 
 Config.Paycheck = {
     Enable = false,
-    Interval = 7 * 60000 -- Every 7 Minutes
+    Interval = 7 -- Every 7 Minutes
 }
 
 Config.OxInventory = ESX.GetConfig().OxInventory

--- a/config.lua
+++ b/config.lua
@@ -5,6 +5,8 @@ Config.Paycheck = {
     Interval = 7 * 60000 -- Every 7 Minutes
 }
 
+Config.OxInventory = ESX.GetConfig().OxInventory
+
 -- You should not need BusinessAccounts when using ESX & esx_society
 Config.BusinessAccounts = {
     -- ['police'] = { -- Job Name

--- a/config.lua
+++ b/config.lua
@@ -23,5 +23,7 @@ Config.BusinessAccounts = {
 
 Config.Locale = {
     deposited = "Deposited money into society account",
-    withdrew = "Withdrew money from society account"
+    withdrew = "Withdrew money from society account",
+    addItemSuccess = 'You got new Visa.',
+    addItemFailed = 'Failed to give new visa, reason:'
 }

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,10 @@
 Config = {}
 
+Config.Paycheck = {
+    Enable = false,
+    Interval = 7 * 60000 -- Every 7 Minutes
+}
+
 -- You should not need BusinessAccounts when using ESX & esx_society
 Config.BusinessAccounts = {
     -- ['police'] = { -- Job Name

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -10,3 +10,5 @@ server_scripts {
   'server.lua',
   'config.lua'
 }
+
+provide 'esx_billing'

--- a/server.lua
+++ b/server.lua
@@ -37,6 +37,42 @@ local function getCash(src)
     return xPlayer.getMoney()
 end
 
+if Config.OxInventory then
+	local function getCards(source)
+		local xPlayer = ESX.GetPlayerFromId(source)
+		local cards = exports.ox_inventory:Search(xPlayer.source, 'search', 'visa')
+		local retval = {}
+		if cards then 
+			for k, v in pairs(cards) do
+				retval[#retval+1] = {
+					id = v.info.id,
+					holder = v.info.holder,
+					number = v.info.number
+				}
+			end
+		end
+		return retval
+	end
+
+	local function giveCard(source, card)
+		local xPlayer = ESX.GetPlayerFromId(source)
+		local info = {
+			id = card.id,
+			holder = card.holder,
+			number = card.number
+		}
+
+		exports.ox_inventory:AddItem(xPlayer.source, 'visa', 1, info, nil, function(success, reason)
+			if success then
+				xPlayer.showNotification(Config.Locale.addItemSuccess)
+			else
+				xPlayer.showNotification(string.format("%s %s",Config.Locale.addItemSuccess,reason))
+			end
+		end)
+	end
+end
+
+
 local function syncBankBalance(account)
     local society = nil
     TriggerEvent('esx_society:getSociety', account.ownerIdentifier, function(_society)
@@ -170,6 +206,10 @@ exports("addCash", addCash)
 exports("removeCash", removeCash)
 exports("getCash", getCash)
 exports("getBank", getBank)
+if Config.OxInventory then
+	exports("giveCard", giveCard)
+	exports("getCards", getCards)
+end
 
 -- EVENTS: GLOBAL
 AddEventHandler("playerDropped", function()

--- a/server.lua
+++ b/server.lua
@@ -152,14 +152,9 @@ end
 local function updateBusinessAccountAccess(player, playerJob, playerLastJob)
     local citizenid = player.identifier
     local playerSrc = player.source
+    local currentUniqueAccount = playerLastJob and exports.pefcl:getUniqueAccount(playerSrc, playerLastJob.name).data
 
-    if Config.BusinessAccounts[playerJob.name] == nil then
-        return
-    end
-
-    local currentUniqueAccount = exports.pefcl:getUniqueAccount(playerSrc, playerJob.name).data;
-
-    if playerLastJob ~= nil and playerLastJob.name then
+    if playerLastJob and currentUniqueAccount and playerLastJob.name ~= playerJob.name and playerLastJob.grade >= Config.BusinessAccounts[playerLastJob.name].ContributorRole then
         print("Removing from last job ..", playerLastJob.name)
 
         local data = {

--- a/server.lua
+++ b/server.lua
@@ -38,38 +38,38 @@ local function getCash(src)
 end
 
 if Config.OxInventory then
-	local function getCards(source)
-		local xPlayer = ESX.GetPlayerFromId(source)
-		local cards = exports.ox_inventory:Search(xPlayer.source, 'search', 'visa')
-		local retval = {}
-		if cards then 
-			for k, v in pairs(cards) do
-				retval[#retval+1] = {
-					id = v.info.id,
-					holder = v.info.holder,
-					number = v.info.number
-				}
-			end
-		end
-		return retval
+    local function getCards(source)
+        local xPlayer = ESX.GetPlayerFromId(source)
+        local cards = exports.ox_inventory:Search(xPlayer.source, 'search', 'visa')
+        local retval = {}
+        if cards then 
+            for k, v in pairs(cards) do
+                retval[#retval+1] = {
+                    id = v.info.id,
+                    holder = v.info.holder,
+                    number = v.info.number
+                }
+            end
 	end
+	return retval
+    end
 
-	local function giveCard(source, card)
-		local xPlayer = ESX.GetPlayerFromId(source)
-		local info = {
-			id = card.id,
-			holder = card.holder,
-			number = card.number
-		}
+    local function giveCard(source, card)
+        local xPlayer = ESX.GetPlayerFromId(source)
+        local info = {
+            id = card.id,
+            holder = card.holder,
+            number = card.number
+        }
 
-		exports.ox_inventory:AddItem(xPlayer.source, 'visa', 1, info, nil, function(success, reason)
-			if success then
-				xPlayer.showNotification(Config.Locale.addItemSuccess)
-			else
-				xPlayer.showNotification(string.format("%s %s",Config.Locale.addItemSuccess,reason))
-			end
-		end)
-	end
+        exports.ox_inventory:AddItem(xPlayer.source, 'visa', 1, info, nil, function(success, reason)
+            if success then
+                xPlayer.showNotification(Config.Locale.addItemSuccess)
+            else
+                xPlayer.showNotification(string.format("%s %s",Config.Locale.addItemSuccess,reason))
+            end
+        end)
+    end
 end
 
 

--- a/server.lua
+++ b/server.lua
@@ -362,7 +362,7 @@ end)
 if Config.Paycheck.Enable then
     CreateThread(function()
         while true do
-            Wait(Config.PaycheckInterval)
+            Wait(Config.Paycheck.Interval * 60000)
             local xPlayers = ESX.GetExtendedPlayers()
             for i = 1, #(xPlayers) do
                 local xPlayer = xPlayers[i]
@@ -400,4 +400,3 @@ if Config.Paycheck.Enable then
         end
     end)
 end
-

--- a/server.lua
+++ b/server.lua
@@ -337,3 +337,25 @@ AddEventHandler('pefcl:changedDefaultAccount', function(account)
     syncBankBalance(account)
 end)
 
+RegisterServerEvent('esx_billing:sendBill')
+AddEventHandler('esx_billing:sendBill', function(playerId, sharedAccountName, label, amount)
+    local xPlayer = ESX.GetPlayerFromId(source)
+    local xTarget = ESX.GetPlayerFromId(playerId)
+    amount = ESX.Math.Round(amount)
+
+    if amount > 0 and xTarget then
+        TriggerEvent('esx_addonaccount:getSharedAccount', sharedAccountName, function(account)
+            if account then
+                local akaun = sharedAccountName
+                if string.match(akaun, 'society_') then
+                    akaun = akaun:gsub('society_', '')
+                end
+
+                    exports.pefcl:createInvoice(source, { to = xTarget.getName(), toIdentifier = xTarget.identifier, from = xPlayer.getName(), fromIdentifier = xPlayer.identifier, amount = amount, message = label, receiverAccountIdentifier = akaun, expiresAt = expiresAt})
+            else
+                    exports.pefcl:createInvoice(source, { to = xTarget.getName(), toIdentifier = xTarget.identifier, from = xPlayer.getName(), fromIdentifier = xPlayer.identifier, amount = amount, message = label, receiverAccountIdentifier = xPlayer.identifier, expiresAt = expiresAt})
+            end
+        end)
+    end
+end)
+


### PR DESCRIPTION
This pull request should handle remove company account correctly.

Take over esx_billing and let pefcl handle the billing but need to remove esx_billing.

Paycheck also will handle by pefcl but need to disable on es_extended/server/paycheck.lua

Add bank card if user use ox_inventory instead esx inventory.